### PR TITLE
Switch to `github-pages` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'jekyll'
-gem "jekyll-sitemap"
-gem 'octopress', '~> 3.0.0.rc.12'
 gem 'github-pages'
-gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     RedCloth (4.2.9)
-    activesupport (4.1.6)
+    activesupport (4.1.7)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -18,9 +18,10 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     colorator (0.1)
-    execjs (2.2.1)
+    execjs (2.2.2)
     fast-stemmer (1.0.2)
-    ffi (1.9.5-x64-mingw32)
+    ffi (1.9.6)
+    ffi (1.9.6-x64-mingw32)
     gemoji (2.1.0)
     github-pages (28)
       RedCloth (= 4.2.9)
@@ -63,7 +64,7 @@ GEM
     jekyll-mentions (0.1.3)
       html-pipeline (~> 1.9.0)
       jekyll (~> 2.0)
-    jekyll-paginate (1.0.0)
+    jekyll-paginate (1.1.0)
     jekyll-redirect-from (0.6.2)
       jekyll (~> 2.0)
     jekyll-sass-converter (1.2.0)
@@ -86,25 +87,10 @@ GEM
     mercenary (0.3.4)
     mini_portile (0.6.0)
     minitest (5.4.2)
+    nokogiri (1.6.3.1)
+      mini_portile (= 0.6.0)
     nokogiri (1.6.3.1-x64-mingw32)
       mini_portile (= 0.6.0)
-    octopress (3.0.0.rc.15)
-      jekyll (~> 2.0)
-      mercenary (~> 0.3.2)
-      octopress-deploy
-      octopress-docs
-      titlecase
-    octopress-deploy (1.0.0)
-      colorator
-      octopress-docs
-    octopress-docs (0.0.8)
-      jekyll (~> 2.0)
-      octopress-escape-code (~> 1.0)
-      octopress-hooks (~> 2.0)
-    octopress-escape-code (1.0.2)
-      octopress-hooks (~> 2.0)
-    octopress-hooks (2.2.1)
-      jekyll (~> 2.0)
     parslet (1.5.0)
       blankslate (~> 2.0)
     posix-spawn (0.3.9)
@@ -117,23 +103,19 @@ GEM
     rdiscount (2.1.7)
     redcarpet (3.1.2)
     safe_yaml (1.0.4)
-    sass (3.4.5)
+    sass (3.4.7)
     thread_safe (0.3.4)
     timers (4.0.1)
       hitimes
-    titlecase (0.1.1)
-    toml (0.1.1)
+    toml (0.1.2)
       parslet (~> 1.5.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     yajl-ruby (1.1.0)
 
 PLATFORMS
+  ruby
   x64-mingw32
 
 DEPENDENCIES
   github-pages
-  jekyll
-  jekyll-redirect-from
-  jekyll-sitemap
-  octopress (~> 3.0.0.rc.12)


### PR DESCRIPTION
This will keep your local environment in sync with what GitHub is running on their servers.

You'll only have to `bundle update` when GitHub deploys a new version.
