### PR TITLE
Change self-referencing URL from http --> https

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 
 title:            SeanKilleen.com
 locale:           en_US
-url:              http://SeanKilleen.com
+url:              https://SeanKilleen.com
 
 
 # Jekyll configuration


### PR DESCRIPTION
To avoid https warnings when loading things like bio photos, etc. that are driven by the config.yml file.