### PR TITLE
update bundler version to 2.2.16

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,4 +296,4 @@ DEPENDENCIES
   wdm
 
 BUNDLED WITH
-   2.1.4
+   2.2.16


### PR DESCRIPTION
https://answers.netlify.com/t/bundler-version-mismatch-nokgiri-dependency-issue-failing-jekyll-builds/36009