### PR TITLE
Lock html-proofer to v4 to avoid build failure on GitHub Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 gem 'github-pages', group: :jekyll_plugins
 gem 'rake'
 gem 'tzinfo-data'
-gem 'html-proofer'
+gem 'html-proofer', '~> 4.4.1'
 gem 'jekyll-github-metadata'
 gem 'minimal-mistakes-jekyll'
 gem 'jekyll-include-cache'


### PR DESCRIPTION
html-proofer v5 relies on async which relies on io which relies on ruby 3.x.

GitHub Pages [uses ruby 2.7.4](https://pages.github.com/versions/), so I've locked Netlify to that as well. 

So, with the upgrade of html-proofer to v5, the builds and deployments will fail.

This PR locks it to v4.