### PR TITLE
Fix GitHub actions code snippets

### DIFF
--- a/_posts/2024-03-27-beautiful-net-test-reports-using-github-actions.md
+++ b/_posts/2024-03-27-beautiful-net-test-reports-using-github-actions.md
@@ -58,6 +58,7 @@ Some of these steps need to write pull requests comments, etc. so in the job def
 First, I check out the code and set up .NET:
 
 ```yaml
+{% raw %}
 - name: Check out the code
   uses: actions/checkout@v4
   with:
@@ -67,13 +68,16 @@ First, I check out the code and set up .NET:
   with:
     dotnet-version: |
       8.x
+{% endraw %}
 ```
 
 Next, we run our tests:
 
 ```yaml
+{% raw %}
 - name: "Restore/Build/Test"
   run: dotnet test --configuration Release --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+{% endraw %}
 ```
 
 A few things to note here:
@@ -87,6 +91,7 @@ A few things to note here:
 First, we combine our coverage reports. This is because each project has its own coverage output, so we need to combine them.
 
 ```yaml
+{% raw %}
 - name: Combine Coverage Reports # This is because one report is produced per project, and we want one result for all of them.
   uses: danielpalme/ReportGenerator-GitHub-Action@5.2.4
   with:
@@ -98,22 +103,26 @@ First, we combine our coverage reports. This is because each project has its own
     tag: "${{ github.run_number }}_${{ github.run_id }}" # Optional tag or build version.
     customSettings: "" # Optional custom settings (separated by semicolon). See: https://github.com/danielpalme/ReportGenerator/wiki/Settings.
     toolpath: "reportgeneratortool" # Default directory for installing the dotnet tool.
+{% endraw %}
 ```
 
 I then choose to upload the combined coverage report to our build's artifacts:
 
 ```yaml
+{% raw %}
 - name: Upload Combined Coverage XML
   uses: actions/upload-artifact@v4
   with:
     name: coverage
     path: ${{ github.workspace }}/Cobertura.xml
     retention-days: 5
+{% endraw %}
 ```
 
 Next up, we publish the coverage report -- this takes the `Cobertura.xml` file and turns it into `code-coverage-results.md`, a nice Markdown file.
 
 ```yaml
+{% raw %}
 - name: Publish Code Coverage Report
   uses: irongut/CodeCoverageSummary@v1.3.0
   with:
@@ -126,6 +135,7 @@ Next up, we publish the coverage report -- this takes the `Cobertura.xml` file a
     indicators: true
     output: both
     thresholds: "10 30"
+{% endraw %}
 ```
 
 A few things to note here:
@@ -137,12 +147,14 @@ A few things to note here:
 Lastly, I surface the code coverage statistics in a PR comment:
 
 ```yaml
+{% raw %}
 - name: Add Coverage PR Comment
   uses: marocchino/sticky-pull-request-comment@v2
   if: github.event_name == 'pull_request'
   with:
     recreate: true
     path: code-coverage-results.md
+{% endraw %}
 ```
 
 ## Reporting on Test Outcomes
@@ -152,22 +164,26 @@ Coverage is one thing, but knowing whether our tests have passed or failed is th
 I choose to upload the test results to my build's artifacts:
 
 ```yaml
+{% raw %}
 - name: Upload Test Result Files
   uses: actions/upload-artifact@v4
   with:
     name: test-results
     path: ${{ github.workspace }}/**/TestResults/**/*
     retention-days: 5
+{% endraw %}
 ```
 
 And then I use another great GitHub Action to publish those results:
 
 ```yaml
+{% raw %}
 - name: Publish Test Results
   uses: EnricoMi/publish-unit-test-result-action@v2.16.1
   if: always()
   with:
     trx_files: "${{ github.workspace }}/**/*.trx"
+{% endraw %}
 ```
 
 Notes:


### PR DESCRIPTION
Some of the variables were getting lopped off due to the liquid syntax parser. I had to mark them as raw.